### PR TITLE
Enable URL concatenation

### DIFF
--- a/purl/__init__.py
+++ b/purl/__init__.py
@@ -6,10 +6,10 @@ __author__ = 'David Winterbottom'
 __license__ = 'MIT'
 
 try:
-    from urllib.parse import parse_qs, urlencode, urlparse
+    from urllib.parse import parse_qs, urlencode, urlparse, urljoin
 except ImportError:
     from urllib import urlencode
-    from urlparse import parse_qs, urlparse
+    from urlparse import parse_qs, urlparse, urljoin
 from collections import namedtuple
 
 
@@ -110,6 +110,12 @@ class URL(object):
 
     def __ne__(self, other):
         return self._tuple != other._tuple
+
+    def __add__(self, other):
+        return URL(urljoin(self.as_string(), str(other)))
+
+    def __radd__(self, other):
+        return URL(urljoin(str(other), self.as_string()))
 
     def __getstate__(self):
         return tuple(self._tuple)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -317,3 +317,18 @@ class QueryParamListTests(TestCase):
         url = base.append_query_param('p', 'c')
         values = url.query_param('p', as_list=True)
         self.assertEqual(['c'], values)
+
+
+class ConcatenationTests(TestCase):
+
+    def test_concatenation(self):
+        left = URL(host='127.0.0.1', path='/some_path/')
+        right = '../other_path/'
+        joined = left + right
+        self.assertEqual('http://127.0.0.1/other_path/', joined.as_string())
+
+    def test_reverse_concatenation(self):
+        left = 'http://127.0.0.1/some_path/'
+        right = URL(path='../other_path/')
+        joined = left + right
+        self.assertEqual('http://127.0.0.1/other_path/', joined.as_string())


### PR DESCRIPTION
Example:

``` python
>>> str(URL('/some_path/') + URL('../other_path/'))
'/other_path/'
```
