### PR TITLE
decode all urls to ascii

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ purl - A simple Python URL class
 ================================
 
 A simple, immutable URL class with a clean API for interrogation and
-manipulation.  
+manipulation.
 
 Docs
 ----
@@ -42,42 +42,42 @@ URL objects are immutable - all mutator methods return a new instance.
 Interrogate::
 
     >>> u = URL(u'https://www.google.com/search?q=testing')
-    >>> u.scheme()      
-    u'https'
-    >>> u.host() 
+    >>> u.scheme()
+    'https'
+    >>> u.host()
     u'www.google.com'
     >>> u.domain()
     u'www.google.com'
     >>> u.username()
-    >>> u.password()    
-    >>> u.netloc()   
+    >>> u.password()
+    >>> u.netloc()
     u'www.google.com'
-    >>> u.port()      
-    >>> u.path()       
-    u'/search'
-    >>> u.query()       
-    u'q=testing'
-    >>> u.fragment()  
+    >>> u.port()
+    >>> u.path()
+    '/search'
+    >>> u.query()
+    'q=testing'
+    >>> u.fragment()
     ''
-    >>> u.path_segment(0) 
+    >>> u.path_segment(0)
     u'search'
-    >>> u.path_segments()  
+    >>> u.path_segments()
     (u'search',)
-    >>> u.query_param('q')  
-    u'testing'
-    >>> u.query_param('q', as_list=True) 
-    [u'testing']
-    >>> u.query_param('lang', default=u'GB') 
+    >>> u.query_param('q')
+    'testing'
+    >>> u.query_param('q', as_list=True)
+    ['testing']
+    >>> u.query_param('lang', default=u'GB')
     u'GB'
-    >>> u.query_params() 
-    {u'q': [u'testing']}
-    >>> u.has_query_param('q') 
+    >>> u.query_params()
+    {'q': ['testing']}
+    >>> u.has_query_param('q')
     True
-    >>> u.has_query_params(('q', 'r')) 
+    >>> u.has_query_params(('q', 'r'))
     False
-    >>> u.subdomains()   
+    >>> u.subdomains()
     [u'www', u'google', u'com']
-    >>> u.subdomain(0)   
+    >>> u.subdomain(0)
     u'www'
 
 Note that each accessor method is overloaded to be a mutator method too, similar
@@ -86,7 +86,7 @@ to the jQuery API.  Eg::
     >>> u = URL.from_string('https://github.com/codeinthehole')
 
     # Access
-    >>> u.path_segment(0) 
+    >>> u.path_segment(0)
     u'codeinthehole'
 
     # Mutate (creates a new instance)

--- a/purl/__init__.py
+++ b/purl/__init__.py
@@ -79,6 +79,8 @@ class URL(object):
     def __init__(self, url_str=None, host=None, username=None, password=None,
                  scheme=None, port=None, path=None, query=None, fragment=None):
         if url_str is not None:
+            if isinstance(url_str, unicode):
+                url_str = url_str.encode('ascii')
             params = parse(url_str)
         else:
             # Defaults

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
 from unittest import TestCase
 import pickle
+import urllib
 
 from purl import URL
 
@@ -177,6 +179,25 @@ class SimpleExtractionTests(TestCase):
 
     def test_path_segments(self):
         self.assertEqual(('blog', 'article', '1'), self.url.path_segments())
+
+
+class UnicodeExtractionTests(TestCase):
+    def setUp(self):
+        self.unicode_param = u'значение'
+        self.urlencoded_param = urllib.quote(
+            self.unicode_param.encode('utf8'))
+        url = 'http://www.google.com/blog/article/1?q=' + self.urlencoded_param
+        self.ascii_url = URL.from_string(url)
+        # django request.get_full_path() returns url as unicode
+        self.unicode_url = URL.from_string(unicode(url))
+
+    def test_get_query_param_ascii_url(self):
+        params = self.ascii_url.query_params()
+        self.assertEqual(params['q'][0].decode('utf8'), self.unicode_param)
+
+    def test_get_query_param_unicode_url(self):
+        params = self.unicode_url.query_params()
+        self.assertEqual(params['q'][0].decode('utf8'), self.unicode_param)
 
 
 class NoTrailingSlashTests(TestCase):


### PR DESCRIPTION
`urlparse.parse_qs` will return bad value, when input url is a unicode instance and contains encoded non-ascii data. Problem described in details here: [http://www.lexev.org/en/2013/parse-url-which-chontains-unicode-query-using-urlp/](http://www.lexev.org/en/2013/parse-url-which-chontains-unicode-query-using-urlp/)

For some reason, django's `request.get_full_path()` returns url as unicode instance. Faced that problem during developing a faceted search in [django-oscar](https://github.com/tangentlabs/django-oscar)

Tests are attached.

In short:

```
>>> import urlparse, urllib
>>> value = urllib.quote(u'значение'.encode('utf8'))
>>> query = u"key=%s" % value
>>> query
u'key=%D0%B7%D0%BD%D0%B0%D1%87%D0%B5%D0%BD%D0%B8%D0%B5'
>>> query_dict = urlparse.parse_qs(query)
>>> query_dict
{u'key': [u'\xd0\xb7\xd0\xbd\xd0\xb0\xd1\x87\xd0\xb5\xd0\xbd\xd0\xb8\xd0\xb5']}
>>> urllib.urlencode(query_dict, doseq=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "../urllib.py", line 1337, in urlencode
    l.append(k + '=' + quote_plus(str(elt)))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-15: ordinal not in range(128)
```

But, when construct query without **u**, it works fine:

```
>>> query = "key=%s" % value
>>> query_dict = urlparse.parse_qs(query)
>>> query_dict
{'key': ['\xd0\xb7\xd0\xbd\xd0\xb0\xd1\x87\xd0\xb5\xd0\xbd\xd0\xb8\xd0\xb5']}
>>> urllib.urlencode(query_dict, doseq=True)
'key=%D0%B7%D0%BD%D0%B0%D1%87%D0%B5%D0%BD%D0%B8%D0%B5'
```
