### PR TITLE
Add classifier trove (Python 3, license, audience)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,10 @@ setup(
     install_requires=['six'],
     include_package_data=True,
     package_data={'': ['LICENSE']},
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+    ],
 )


### PR DESCRIPTION
I noticed the missing Python 3 classifier while using caniusepython3 on my requirements.txt file.
