### PR TITLE
Quote special characters when updating the path.

### DIFF
--- a/purl/url.py
+++ b/purl/url.py
@@ -280,7 +280,8 @@ class URL(object):
         if value:
             if not value.startswith('/'):
                 value = '/' + value
-            return URL._mutate(self, path=value)
+            encoded_value = unicode_quote(value)
+            return URL._mutate(self, path=encoded_value)
         return self._tuple.path
 
     def query(self, value=None):

--- a/tests/url_tests.py
+++ b/tests/url_tests.py
@@ -242,6 +242,10 @@ class BuilderTests(TestCase):
         url = URL.from_string('http://www.google.com/').path('search')
         self.assertEqual('/search', url.path())
 
+    def test_set_path_with_special_chars(self):
+        url = URL.from_string('http://www.google.com/').path('search something')
+        self.assertEqual('/search%20something', url.path())
+
     def test_set_query(self):
         url = URL.from_string('http://www.google.com/').query('q=testing')
         self.assertEqual('testing', url.query_param('q'))


### PR DESCRIPTION
`URL.path` method should quote special characters the same way `URL.path_segments` does.
