### PR TITLE
Fix passwordless url

### DIFF
--- a/purl/url.py
+++ b/purl/url.py
@@ -96,14 +96,18 @@ def parse(url_str):
     Extract all parts from a URL string and return them as a dictionary
     """
     url_str = to_unicode(url_str)
-
     result = urlparse(url_str)
     netloc_parts = result.netloc.split('@')
     if len(netloc_parts) == 1:
         username = password = None
         host = netloc_parts[0]
     else:
-        username, password = netloc_parts[0].split(':')
+        user_and_pass = netloc_parts[0].split(':')
+        if len(user_and_pass) == 2:
+            username, password = user_and_pass
+        elif len(user_and_pass) == 1:
+            username = user_and_pass[0]
+            password = None
         host = netloc_parts[1]
 
     if host and ':' in host:
@@ -211,6 +215,8 @@ class URL(object):
         url = self._tuple
         if url.username and url.password:
             netloc = '%s:%s@%s' % (url.username, url.password, url.host)
+        elif url.username and not url.password:
+            netloc = '%s@%s' % (url.username, url.host)
         else:
             netloc = url.host
         if url.port:

--- a/tests/url_tests.py
+++ b/tests/url_tests.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-
+from purl import URL
 from unittest import TestCase
+
 import pickle
 
 try:
     from urllib.parse import quote
 except ImportError:
     from urllib import quote
-
-from purl import URL
 
 
 class ConstructorTests(TestCase):
@@ -25,6 +24,10 @@ class ConstructorTests(TestCase):
     def test_url_can_be_created_with_host_and_post(self):
         u = URL(host='localhost', port=8000)
         self.assertEqual('http://localhost:8000/', str(u))
+
+    def test_url_can_be_created_with_username_only(self):
+        u = URL(scheme='postgres', username='user', host='127.0.0.1', port='5432', path='/db_name')
+        self.assertEqual('postgres://user@127.0.0.1:5432/db_name', str(u))
 
     def test_no_args_to_constructor(self):
         u = URL()
@@ -104,6 +107,21 @@ class EdgeCaseExtractionTests(TestCase):
         url = URL.from_string('http://localhost:5000')
         self.assertEqual('localhost', url.host())
         self.assertEqual(5000, url.port())
+
+    def test_passwordless_netloc(self):
+        url = URL.from_string('postgres://user@127.0.0.1:5432/db_name')
+        self.assertEqual('user', url.username())
+        self.assertTrue(url.password() is None)
+
+    def test_unicode_username_and_password(self):
+        url = URL.from_string('postgres://jeść:niejeść@127.0.0.1:5432/db_name')
+        self.assertEqual('jeść', url.username())
+        self.assertEqual('niejeść', url.password())
+
+    def test_unicode_username_only(self):
+        url = URL.from_string('postgres://jeść@127.0.0.1:5432/db_name')
+        self.assertEqual('jeść', url.username())
+        self.assertTrue(url.password() is None)
 
     def test_port_for_https_url(self):
         url = URL.from_string('https://github.com')


### PR DESCRIPTION
It seems like main issues from #20  are solved:
```
>>> from purl import URL
>>> url = URL.from_string('ftp://user@ftp.host')
>>> url.username()
u"[u'user']"
>>> url.password()
>>> if url.password() is None:
...     print 'Works!'
...
...
Works!
>>> url_2 = URL(scheme='http', username='user', host='gmail.com', port='443', path='/resource')
>>> url_2.as_string()
u'http://user@gmail.com:443/resource'
>>>
```

However,I've also wrote some test and it seems like there is unicode related problem there

```
.......................................................................................................F...........................................................
======================================================================
FAIL: test_passwordless_netloc (tests.url_tests.EdgeCaseExtractionTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/phejman/projects/purl/tests/url_tests.py", line 114, in test_passwordless_netloc
    self.assertEqual('user', url.username())
AssertionError: u'user' != u"[u'user']"
- user
+ [u'user']
```