### PR TITLE
Allow to remove username and password from URL

### DIFF
--- a/purl/url.py
+++ b/purl/url.py
@@ -249,7 +249,7 @@ class URL(object):
         :returns: string or new :class:`URL` instance
         """
         #return unicode_unquote(self._tuple.username)
-        if value:
+        if value is not None:
             return URL._mutate(self, username=value)
         return unicode_unquote(self._tuple.username)
 
@@ -260,8 +260,7 @@ class URL(object):
         :param string value: the new password to use
         :returns: string or new :class:`URL` instance
         """
-
-        if value:
+        if value is not None:
             return URL._mutate(self, password=value)
         return unicode_unquote(self._tuple.password)
 


### PR DESCRIPTION
For now, it is impossible to strip username or password from URL by calling `.username("")` or `.password("")`. This small change fixes the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codeinthehole/purl/29)
<!-- Reviewable:end -->
