### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,10 @@ Contents:
 .. image:: https://secure.travis-ci.org/codeinthehole/purl.png
     :target: https://travis-ci.org/codeinthehole/purl
 
-.. image:: https://pypip.in/v/purl/badge.png
+.. image:: https://img.shields.io/pypi/v/purl.svg
     :target: https://crate.io/packages/purl/
 
-.. image:: https://pypip.in/d/purl/badge.png
+.. image:: https://img.shields.io/pypi/dm/purl.svg
     :target: https://crate.io/packages/purl/
 
 .. _`RFC 6570`: http://tools.ietf.org/html/rfc6570


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20purl))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `purl`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.