### PR TITLE
docs: fix simple typo, insteed -> instead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ Changelog
 v1.6 - 2021-05-15
 ~~~~~~~~~~~~~~~~~
 
-* Use `pytest` insteed of `nose`.
+* Use `pytest` instead of `nose`.
 * Fix warning around regex string.
 
 v1.5 - 2019-03-10


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `instead` rather than `insteed`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md